### PR TITLE
Fix typos in the agenda

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -29,11 +29,9 @@ The workshop is divided into the sections listed below. Plan for around 2 hours 
 
 <span style="color: #4e3eb1;"><i class='fas fa-check fa-xs'></i></span> <b> 5. Report and manage key findings for open source issues (15 minutes)</b>
 
-<span style="color: #4e3eb1;"><i class='fas fa-check fa-xs'></i></span> <b> 8. Conclusion (5 minutes)</b>
+<span style="color: #4e3eb1;"><i class='fas fa-check fa-xs'></i></span> <b> 6. Conclusion (5 minutes)</b>
 
-<span style="color: #4e3eb1;"><i class='fas fa-check fa-xs'></i></span> <b> 9. Cleanup (5 minutes)</b>
-
-<span style="color: #4e3eb1;"><i class='fas fa-check fa-xs'></i></span> <b> 10. Survey (5 minutes)</b>
+<span style="color: #4e3eb1;"><i class='fas fa-check fa-xs'></i></span> <b> 7. Survey (5 minutes)</b>
 
 --------
 


### PR DESCRIPTION
*Issue:* 

The agenda was describing items not available for this workshop. 

*Description of changes:*

Fix the typos in the agenda to reflect the topics of the workshop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
